### PR TITLE
pom: change scopes from provided to compile: commons-lang3, mongo-java-driver, spring-beans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,20 +64,18 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
             <version>2.11.1</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <version>3.1.3.RELEASE</version>
-            <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- logging -->


### PR DESCRIPTION
Otherwise, if used in a project that doesn't otherwise, have said dependencies, ClassNotFoundExceptions will occur.

An example from my Grails project:

```
org.apache.commons.lang3.time.DateFormatUtils. Stacktrace follows:
Message: org.apache.commons.lang3.time.DateFormatUtils
    Line | Method
->>  156 | findClass    in org.codehaus.groovy.tools.RootLoader
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
|    424 | loadClass    in java.lang.ClassLoader
|    128 | loadClass .  in org.codehaus.groovy.tools.RootLoader
|    357 | loadClass    in java.lang.ClassLoader
|    133 | logChangeSet in org.mongeez.dao.MongeezDao
|     54 | execute      in org.mongeez.ChangeSetExecutor
|     42 | execute . .  in     ''
|     40 | process      in org.mongeez.Mongeez
|     58 | execute . .  in org.mongeez.MongeezRunner
|     40 | run          in grails.mongeez.MongeezController
|   1145 | runWorker .  in java.util.concurrent.ThreadPoolExecutor
|    615 | run          in java.util.concurrent.ThreadPoolExecutor$Worker
^    724 | run . . . .  in java.lang.Thread    
```
