### PR TITLE
-Add handling for incorrectly setup mongeez.xml file to fix NPE that occ...

### DIFF
--- a/src/main/java/org/mongeez/reader/FilesetXMLReader.java
+++ b/src/main/java/org/mongeez/reader/FilesetXMLReader.java
@@ -42,11 +42,17 @@ public class FilesetXMLReader {
             digester.addSetNext("changeFiles/file", "add");
 
             ChangeFileSet changeFileSet = (ChangeFileSet) digester.parse(file.getInputStream());
-            logger.info("Num of changefiles " + changeFileSet.getChangeFiles().size());
+	    if (changeFileSet != null) {
+		logger.info("Num of changefiles " + changeFileSet.getChangeFiles().size());
 
-            for (ChangeFile changeFile : changeFileSet.getChangeFiles()) {
-                files.add(file.createRelative(changeFile.getPath()));
-            }
+		for (ChangeFile changeFile : changeFileSet.getChangeFiles()) {
+		    files.add(file.createRelative(changeFile.getPath()));
+		}
+	    }
+	    else {
+		logger.error("The file {} doesn't seem to contain a changeFiles declaration. Are you "
+			     + "using the correct file to initialize Mongeez?", file.getFilename());
+	    }
         } catch (IOException e) {
             logger.error("IOException", e);
         } catch (org.xml.sax.SAXException e) {

--- a/src/main/java/org/mongeez/reader/XmlChangeSetReader.java
+++ b/src/main/java/org/mongeez/reader/XmlChangeSetReader.java
@@ -56,10 +56,15 @@ public class XmlChangeSetReader implements ChangeSetReader {
 
         try {
             ChangeSetList changeFileSet = (ChangeSetList) digester.parse(file.getInputStream());
-            for (ChangeSet changeSet : changeFileSet.getList()) {
-                ChangeSetReaderUtil.populateChangeSetResourceInfo(changeSet, file);
-            }
-            changeSets.addAll(changeFileSet.getList());
+	    if (changeFileSet.getList() == null) {
+		logger.warn("Ignoring change file {}, it does not contain any changeSets", file.getFilename());
+	    }
+	    else {
+		for (ChangeSet changeSet : changeFileSet.getList()) {
+		    ChangeSetReaderUtil.populateChangeSetResourceInfo(changeSet, file);
+		}
+		changeSets.addAll(changeFileSet.getList());
+	    }
         } catch (IOException e) {
             logger.error("IOException", e);
         } catch (org.xml.sax.SAXException e) {

--- a/src/test/java/org/mongeez/MongeezTest.java
+++ b/src/test/java/org/mongeez/MongeezTest.java
@@ -84,4 +84,23 @@ public class MongeezTest {
 
         assertEquals(db.getCollection("mongeez").count(), 1);
     }
+
+    @Test(groups = "dao")
+    public void testNoFailureOnEmptyChangeLog() throws Exception {
+        assertEquals(db.getCollection("mongeez").count(), 0);
+
+        Mongeez mongeez = create("mongeez_empty_changelog.xml");
+        mongeez.process();
+
+        assertEquals(db.getCollection("mongeez").count(), 1);
+    }
+
+    @Test(groups = "dao")
+    public void testNoFailureOnNoChangeFilesBlock() throws Exception {
+        assertEquals(db.getCollection("mongeez").count(), 0);
+
+        Mongeez mongeez = create("mongeez_no_changefiles_declared.xml");
+        mongeez.process();
+        assertEquals(db.getCollection("mongeez").count(), 1);
+    }
 }

--- a/src/test/resources/empty_changeset.xml
+++ b/src/test/resources/empty_changeset.xml
@@ -1,0 +1,4 @@
+<!--A changelog with no changes. This can occur on first setup of new projects-->
+<mongoChangeLog>
+</mongoChangeLog> 
+

--- a/src/test/resources/mongeez_empty_changelog.xml
+++ b/src/test/resources/mongeez_empty_changelog.xml
@@ -1,0 +1,6 @@
+<!--
+A mongeez setup with a change file that has no changes in the changelog
+-->
+<changeFiles>
+  <file path="empty_changeset.xml"/>
+</changeFiles>

--- a/src/test/resources/mongeez_no_changefiles_declared.xml
+++ b/src/test/resources/mongeez_no_changefiles_declared.xml
@@ -1,0 +1,5 @@
+<!--
+A mongeez setup with valid xml that does not contain changeFiles root element. Not normal, but causes an NPE
+-->
+<test>
+</test>


### PR DESCRIPTION
Two additions to handle two NullPointerExceptions. 
-The first occurs when you have a valid xml file which does not contain the <changeFiles> block. 
-The second occurs when you have a change file that contains an empty <mongoChangeLog> block 
