### PR TITLE
Allow the use of context in js changesets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     
     <groupId>org.endource</groupId>
     <artifactId>mongeez</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Mongeez</name>
@@ -28,7 +28,7 @@
         <connection>scm:git:git@github.com:shin-nien/mongeez.git</connection>
         <developerConnection>scm:git:git@github.com:shin-nien/mongeez.git</developerConnection>
         <url>git@github.com:shin-nien/mongeez.git</url>
-      <tag>mongeez-0.9.5</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
         <version>7</version>
     </parent>
     
-    <groupId>org.mongeez</groupId>
+    <groupId>org.endource</groupId>
     <artifactId>mongeez</artifactId>
-    <version>0.9.5-SNAPSHOT</version>
+    <version>0.9.5</version>
     <packaging>jar</packaging>
 
     <name>Mongeez</name>
@@ -25,10 +25,19 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:secondmarket/mongeez.git</connection>
-        <developerConnection>scm:git:git@github.com:secondmarket/mongeez.git</developerConnection>
-        <url>git@github.com:secondmarket/mongeez.git</url>
-    </scm>
+        <connection>scm:git:git@github.com:shin-nien/mongeez.git</connection>
+        <developerConnection>scm:git:git@github.com:shin-nien/mongeez.git</developerConnection>
+        <url>git@github.com:shin-nien/mongeez.git</url>
+      <tag>mongeez-0.9.5</tag>
+  </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>bintray-endource-maven-mongeez</id>
+            <name>endource-maven-mongeez</name>
+            <url>https://api.bintray.com/maven/endource/maven/mongeez</url>
+        </repository>
+    </distributionManagement>
 
     <developers>
         <developer>
@@ -118,6 +127,56 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/org/mongeez/reader/FormattedJavascriptChangeSetReader.java
+++ b/src/main/java/org/mongeez/reader/FormattedJavascriptChangeSetReader.java
@@ -39,6 +39,9 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
     private static final Pattern ATTRIBUTE_RUN_ALWAYS_PATTERN =
             Pattern.compile(".*runAlways:(\\w+).*",
                     Pattern.CASE_INSENSITIVE);
+    private static final Pattern ATTRIBUTE_CONTEXT_PATTERN =
+            Pattern.compile(".*context:([\\w,]+).*",
+                    Pattern.CASE_INSENSITIVE);
 
     private static final Logger logger = LoggerFactory.getLogger(FormattedJavascriptChangeSetReader.class);
 
@@ -141,6 +144,7 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
             changeSet.setAuthor(changeSetMatcher.group(1));
             changeSet.setChangeId(changeSetMatcher.group(2));
             changeSet.setRunAlways(parseAttribute(ATTRIBUTE_RUN_ALWAYS_PATTERN.matcher(line), false));
+            changeSet.setContexts(parseOptions(ATTRIBUTE_CONTEXT_PATTERN.matcher(line), ""));
         }
         return changeSet;
     }
@@ -150,6 +154,16 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
         if (attributeMatcher.matches()) {
             attributeValue = Boolean.parseBoolean(attributeMatcher.group(1));
         }
+        return attributeValue;
+    }
+
+    private String parseOptions(Matcher attributeMatcher, String defaultValue) {
+        String attributeValue = defaultValue;
+
+        if (attributeMatcher.matches()) {
+            attributeValue = attributeMatcher.group(1);
+        }
+
         return attributeValue;
     }
 

--- a/src/test/java/org/mongeez/MongeezTest.java
+++ b/src/test/java/org/mongeez/MongeezTest.java
@@ -144,4 +144,45 @@ public class MongeezTest {
         assertEquals(db.getCollection("organization").count(), 2);
         assertEquals(db.getCollection("house").count(), 2);
     }
+
+    @Test(groups = "dao")
+    public void testJsChangesWContextContextNotSet() throws Exception {
+        assertEquals(db.getCollection("mongeez").count(), 0);
+
+        Mongeez mongeez = create("mongeez_js_contexts.xml");
+        mongeez.process();
+        assertEquals(db.getCollection("mongeez").count(), 2);
+        assertEquals(db.getCollection("car").count(), 2);
+        assertEquals(db.getCollection("user").count(), 0);
+        assertEquals(db.getCollection("organization").count(), 0);
+        assertEquals(db.getCollection("house").count(), 0);
+    }
+
+    @Test(groups = "dao")
+    public void testJsChangesWContextContextSetToUsers() throws Exception {
+        assertEquals(db.getCollection("mongeez").count(), 0);
+
+        Mongeez mongeez = create("mongeez_js_contexts.xml");
+        mongeez.setContext("users");
+        mongeez.process();
+        assertEquals(db.getCollection("mongeez").count(), 4);
+        assertEquals(db.getCollection("car").count(), 2);
+        assertEquals(db.getCollection("user").count(), 2);
+        assertEquals(db.getCollection("organization").count(), 0);
+        assertEquals(db.getCollection("house").count(), 2);
+    }
+
+    @Test(groups = "dao")
+    public void testJsChangesWContextContextSetToOrganizations() throws Exception {
+        assertEquals(db.getCollection("mongeez").count(), 0);
+
+        Mongeez mongeez = create("mongeez_js_contexts.xml");
+        mongeez.setContext("organizations");
+        mongeez.process();
+        assertEquals(db.getCollection("mongeez").count(), 4);
+        assertEquals(db.getCollection("car").count(), 2);
+        assertEquals(db.getCollection("user").count(), 0);
+        assertEquals(db.getCollection("organization").count(), 2);
+        assertEquals(db.getCollection("house").count(), 2);
+    }
 }

--- a/src/test/resources/changeset_with_contexts.js
+++ b/src/test/resources/changeset_with_contexts.js
@@ -1,0 +1,24 @@
+//mongeez formatted javascript
+// changeset mlysaght:ChangeSet-1 context:organizations
+db.organization.insert({
+    "Organization" : "10Gen",
+    "Location" : "NYC",
+    DateFounded : {"Year" : 2008, "Month" : 01, "day" :01}
+});
+db.organization.insert({
+    "Organization" : "SecondMarket",
+    "Location" : "NYC",
+    DateFounded : {"Year" : 2004, "Month" : 05, "day" :04}
+});
+
+// changeset mlysaght:ChangeSet-2 context:users
+db.user.insert({ "Name" : "Michael Lysaght"});
+db.user.insert({ "Name" : "Oleksii Iepishkin"});
+
+// changeset exell:ChangeSet-3
+db.car.insert({ "Type" : "Porsche"});
+db.car.insert({ "Type" : "Lamborghini"});
+
+// changeset exell:ChangeSet-4 context:users,organizations
+db.house.insert({ "Type" : "Bungalow"});
+db.house.insert({ "Type" : "Split-Level"});

--- a/src/test/resources/mongeez_js_contexts.xml
+++ b/src/test/resources/mongeez_js_contexts.xml
@@ -1,0 +1,3 @@
+<changeFiles>
+    <file path="changeset_with_contexts.js"/>
+</changeFiles>

--- a/src/test/resources/org/mongeez/reader/changeset_context1.js
+++ b/src/test/resources/org/mongeez/reader/changeset_context1.js
@@ -1,0 +1,16 @@
+//mongeez formatted javascript
+
+//changeset shin:ChangeSet-1
+db.user.insert({ "Name" : "Alice"});
+
+//changeset shin:ChangeSet-2 runAlways:false
+db.user.insert({ "Name" : "Bob"});
+
+//changeset shin:ChangeSet-3 runAlways:true context:test
+db.user.insert({ "Name" : "Charlie"});
+
+//changeset shin:ChangeSet-4 runAlways:true context:test,staging
+db.user.insert({ "Name" : "Edward"});
+
+
+


### PR DESCRIPTION
Contexts are already working for xml files so this is an extension of the same for js changesets.

I guess this means that runAlways isn't the only option anymore?
