### PR TITLE
added context parsing to formatted javascript changesets

### DIFF
--- a/src/main/java/org/mongeez/reader/FormattedJavascriptChangeSetReader.java
+++ b/src/main/java/org/mongeez/reader/FormattedJavascriptChangeSetReader.java
@@ -39,6 +39,9 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
     private static final Pattern ATTRIBUTE_RUN_ALWAYS_PATTERN =
             Pattern.compile(".*runAlways:(\\w+).*",
                     Pattern.CASE_INSENSITIVE);
+    private static final Pattern ATTRIBUTE_CONTEXTS_PATTERN =
+            Pattern.compile(".*contexts:([\\w]+(?:, *[\\w]+)*).*",
+                    Pattern.CASE_INSENSITIVE);
 
     private static final Logger logger = LoggerFactory.getLogger(FormattedJavascriptChangeSetReader.class);
 
@@ -141,6 +144,7 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
             changeSet.setAuthor(changeSetMatcher.group(1));
             changeSet.setChangeId(changeSetMatcher.group(2));
             changeSet.setRunAlways(parseAttribute(ATTRIBUTE_RUN_ALWAYS_PATTERN.matcher(line), false));
+            changeSet.setContexts(parseAttributeString(ATTRIBUTE_CONTEXTS_PATTERN.matcher(line)));
         }
         return changeSet;
     }
@@ -151,6 +155,13 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
             attributeValue = Boolean.parseBoolean(attributeMatcher.group(1));
         }
         return attributeValue;
+    }
+
+    private String parseAttributeString(Matcher attributeMatcher) {
+        if (attributeMatcher.matches()) {
+            return attributeMatcher.group(1);
+        }
+        return null;
     }
 
 }

--- a/src/test/java/org/mongeez/reader/FormattedJavascriptChangeSetReaderTest.java
+++ b/src/test/java/org/mongeez/reader/FormattedJavascriptChangeSetReaderTest.java
@@ -19,6 +19,8 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class FormattedJavascriptChangeSetReaderTest {
     @Test
@@ -144,6 +146,23 @@ public class FormattedJavascriptChangeSetReaderTest {
     public void testGetChangeSetsIOFailure() throws Exception {
         List<ChangeSet> changeSets = parse("changeset_nonexistant.js");
         assertEquals(changeSets.size(), 0);
+    }
+
+    @Test
+    public void testChangeSetWithContexts() throws Exception {
+        List<ChangeSet> changeSets = parse("changeset_contexts.js");
+        assertEquals(changeSets.size(), 5);
+        assertEquals("users", changeSets.get(0).getContexts());
+
+        assertEquals("users,organizations", changeSets.get(1).getContexts());
+
+        assertTrue(changeSets.get(2).isRunAlways());
+        assertEquals("users,organizations", changeSets.get(2).getContexts());
+
+        assertEquals("users, organizations", changeSets.get(3).getContexts());
+
+        assertTrue(changeSets.get(4).isRunAlways());
+        assertEquals("users, organizations", changeSets.get(4).getContexts());
     }
 
     private List<ChangeSet> parse(String fileName) {

--- a/src/test/resources/org/mongeez/reader/changeset_contexts.js
+++ b/src/test/resources/org/mongeez/reader/changeset_contexts.js
@@ -1,0 +1,16 @@
+// mongeez formatted javascript
+
+// changeset mlysaght:ChangeSet-2 contexts:users
+db.user.insert({"Name": "Michael Lysaght"})
+
+// changeset exell:ChangeSet-4 contexts:users,organizations
+db.house.insert({"Type": "Bungalow"});
+
+// changeset exell:ChangeSet-4 contexts:users,organizations runAlways:true
+db.house.insert({"Type": "Bungalow"});
+
+// changeset exell:ChangeSet-4 contexts:users, organizations
+db.house.insert({"Type": "Bungalow"});
+
+// changeset exell:ChangeSet-4 contexts:users, organizations runAlways:true
+db.house.insert({"Type": "Bungalow"});


### PR DESCRIPTION
I have added the parsing of contexts from formatted javascript changesets. The parameter is called 'context' just as in the XML version.

Examples vor valid uses:
```
// changeset author:changesetId contexts:Development
...

// changeset author:changesetId contexts:Development,IntegrationTest
...

// changeset author:changesetId contexts:Developments, IntegrationTest
...
```