### PR TITLE
Add tests to verify MongoClient

### DIFF
--- a/src/test/java/org/mongeez/AbstractMongeezTest.java
+++ b/src/test/java/org/mongeez/AbstractMongeezTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2011 SecondMarket Labs, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.mongeez;
+
+import static org.testng.Assert.assertEquals;
+
+import org.mongeez.validation.ValidationException;
+import org.springframework.core.io.ClassPathResource;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.mongodb.Mongo;
+
+@Test
+public abstract class AbstractMongeezTest {
+	
+    private static final String DB_NAME = "test_mongeez";
+
+    protected abstract Mongo prepareDatabase(String databaseName);
+    protected abstract long collectionCount(String collection);
+    
+    private Mongo mongo;
+    
+    @BeforeMethod
+    protected void setUp() throws Exception {
+    	mongo = prepareDatabase(DB_NAME);
+    }
+    
+    private Mongeez create(String path) {
+        Mongeez mongeez = new Mongeez();
+        mongeez.setFile(new ClassPathResource(path));
+        mongeez.setMongo(mongo);
+        mongeez.setDbName(DB_NAME);
+        return mongeez;
+    }
+
+    @Test(groups = "dao")
+    public void testMongeez() throws Exception {
+        Mongeez mongeez = create("mongeez.xml");
+
+        mongeez.process();
+
+        assertEquals(collectionCount("mongeez"), 5);
+
+        assertEquals(collectionCount("organization"), 2);
+        assertEquals(collectionCount("user"), 2);
+    }
+
+    @Test(groups = "dao")
+    public void testRunTwice() throws Exception {
+        testMongeez();
+        testMongeez();
+    }
+
+    @Test(groups = "dao")
+    public void testFailOnError_False() throws Exception {
+        assertEquals(collectionCount("mongeez"), 0);
+
+        Mongeez mongeez = create("mongeez_fail.xml");
+        mongeez.process();
+
+        assertEquals(collectionCount("mongeez"), 2);
+    }
+
+    @Test(groups = "dao", expectedExceptions = com.mongodb.MongoCommandException.class)
+    public void testFailOnError_True() throws Exception {
+        Mongeez mongeez = create("mongeez_fail_fail.xml");
+        mongeez.process();
+    }
+
+    @Test(groups = "dao")
+    public void testNoFiles() throws Exception {
+        Mongeez mongeez = create("mongeez_empty.xml");
+        mongeez.process();
+
+        assertEquals(collectionCount("mongeez"), 1);
+    }
+
+    @Test(groups = "dao")
+    public void testNoFailureOnEmptyChangeLog() throws Exception {
+        assertEquals(collectionCount("mongeez"), 0);
+
+        Mongeez mongeez = create("mongeez_empty_changelog.xml");
+        mongeez.process();
+
+        assertEquals(collectionCount("mongeez"), 1);
+    }
+
+    @Test(groups = "dao")
+    public void testNoFailureOnNoChangeFilesBlock() throws Exception {
+        assertEquals(collectionCount("mongeez"), 0);
+
+        Mongeez mongeez = create("mongeez_no_changefiles_declared.xml");
+        mongeez.process();
+        assertEquals(collectionCount("mongeez"), 1);
+    }
+
+    @Test(groups = "dao")
+    public void testChangesWContextContextNotSet() throws Exception {
+        assertEquals(collectionCount("mongeez"), 0);
+
+        Mongeez mongeez = create("mongeez_contexts.xml");
+        mongeez.process();
+        assertEquals(collectionCount("mongeez"), 2);
+        assertEquals(collectionCount("car"), 2);
+        assertEquals(collectionCount("user"), 0);
+        assertEquals(collectionCount("organization"), 0);
+        assertEquals(collectionCount("house"), 0);
+    }
+
+    @Test(groups = "dao")
+    public void testChangesWContextContextSetToUsers() throws Exception {
+        assertEquals(collectionCount("mongeez"), 0);
+
+        Mongeez mongeez = create("mongeez_contexts.xml");
+        mongeez.setContext("users");
+        mongeez.process();
+        assertEquals(collectionCount("mongeez"), 4);
+        assertEquals(collectionCount("car"), 2);
+        assertEquals(collectionCount("user"), 2);
+        assertEquals(collectionCount("organization"), 0);
+        assertEquals(collectionCount("house"), 2);
+    }
+
+    @Test(groups = "dao")
+    public void testChangesWContextContextSetToOrganizations() throws Exception {
+        assertEquals(collectionCount("mongeez"), 0);
+
+        Mongeez mongeez = create("mongeez_contexts.xml");
+        mongeez.setContext("organizations");
+        mongeez.process();
+        assertEquals(collectionCount("mongeez"), 4);
+        assertEquals(collectionCount("car"), 2);
+        assertEquals(collectionCount("user"), 0);
+        assertEquals(collectionCount("organization"), 2);
+        assertEquals(collectionCount("house"), 2);
+    }
+
+    @Test(groups = "dao", expectedExceptions = ValidationException.class)
+    public void testFailDuplicateIds() throws Exception {
+        Mongeez mongeez = create("mongeez_fail_on_duplicate_changeset_ids.xml");
+        mongeez.process();
+    }
+}

--- a/src/test/java/org/mongeez/AbstractMongeezTest.java
+++ b/src/test/java/org/mongeez/AbstractMongeezTest.java
@@ -23,19 +23,19 @@ import com.mongodb.Mongo;
 
 @Test
 public abstract class AbstractMongeezTest {
-	
+
     private static final String DB_NAME = "test_mongeez";
 
     protected abstract Mongo prepareDatabase(String databaseName);
     protected abstract long collectionCount(String collection);
-    
+
     private Mongo mongo;
-    
+
     @BeforeMethod
     protected void setUp() throws Exception {
-    	mongo = prepareDatabase(DB_NAME);
+        mongo = prepareDatabase(DB_NAME);
     }
-    
+
     private Mongeez create(String path) {
         Mongeez mongeez = new Mongeez();
         mongeez.setFile(new ClassPathResource(path));

--- a/src/test/java/org/mongeez/MongeezMongoClientTest.java
+++ b/src/test/java/org/mongeez/MongeezMongoClientTest.java
@@ -20,20 +20,20 @@ import org.testng.annotations.Test;
 
 @Test
 public class MongeezMongoClientTest extends AbstractMongeezTest {
-	
+
     private MongoDatabase mongoDatabase;
 
     @Override
-	protected Mongo prepareDatabase(String databaseName) {
+    protected Mongo prepareDatabase(String databaseName) {
         MongoClient mongoClient = new MongoClient();
         mongoDatabase = mongoClient.getDatabase(databaseName);
         mongoDatabase.drop();
-		return mongoClient;
-	}
-    
-	@Override
-	protected long collectionCount(String collection) {
-		return mongoDatabase.getCollection(collection).count();
-	}
+        return mongoClient;
+    }
+
+    @Override
+    protected long collectionCount(String collection) {
+        return mongoDatabase.getCollection(collection).count();
+    }
 
 }

--- a/src/test/java/org/mongeez/MongeezMongoClientTest.java
+++ b/src/test/java/org/mongeez/MongeezMongoClientTest.java
@@ -12,27 +12,28 @@
 
 package org.mongeez;
 
-import com.mongodb.DB;
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 import org.testng.annotations.Test;
 
 @Test
-public class MongeezTest extends AbstractMongeezTest {
+public class MongeezMongoClientTest extends AbstractMongeezTest {
 	
-    private DB db;
+    private MongoDatabase mongoDatabase;
 
     @Override
 	protected Mongo prepareDatabase(String databaseName) {
-		Mongo mongo = new Mongo();
-        db = mongo.getDB(databaseName);
-        db.dropDatabase();
-		return mongo;
+        MongoClient mongoClient = new MongoClient();
+        mongoDatabase = mongoClient.getDatabase(databaseName);
+        mongoDatabase.drop();
+		return mongoClient;
 	}
     
 	@Override
 	protected long collectionCount(String collection) {
-		return db.getCollection(collection).count();
+		return mongoDatabase.getCollection(collection).count();
 	}
 
 }

--- a/src/test/java/org/mongeez/MongeezTest.java
+++ b/src/test/java/org/mongeez/MongeezTest.java
@@ -19,20 +19,20 @@ import org.testng.annotations.Test;
 
 @Test
 public class MongeezTest extends AbstractMongeezTest {
-	
+
     private DB db;
 
     @Override
-	protected Mongo prepareDatabase(String databaseName) {
-		Mongo mongo = new Mongo();
+    protected Mongo prepareDatabase(String databaseName) {
+        Mongo mongo = new Mongo();
         db = mongo.getDB(databaseName);
         db.dropDatabase();
-		return mongo;
-	}
-    
-	@Override
-	protected long collectionCount(String collection) {
-		return db.getCollection(collection).count();
-	}
+        return mongo;
+    }
+
+    @Override
+    protected long collectionCount(String collection) {
+        return db.getCollection(collection).count();
+    }
 
 }


### PR DESCRIPTION
The current tests only validate the deprecated Mongo class, without validating the new MongoClient class.
- split off tests to an AbstractMongeezTest
- configure all tests to validate both MongoClient and deprecated Mongo classes
