### PR TITLE
Allow to configure a MongoClient instance directly

### DIFF
--- a/src/main/java/org/mongeez/ChangeSetExecutor.java
+++ b/src/main/java/org/mongeez/ChangeSetExecutor.java
@@ -17,6 +17,8 @@ import org.mongeez.commands.Script;
 import org.mongeez.dao.MongeezDao;
 
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +30,11 @@ public class ChangeSetExecutor {
 
     private MongeezDao dao = null;
     private String context = null;
+
+    public ChangeSetExecutor(MongoClient mongoClient, String dbName, String context) {
+        dao = new MongeezDao(mongoClient, dbName);
+        this.context = context;
+    }
 
     public ChangeSetExecutor(Mongo mongo, String dbName, String context) {
         this(mongo, dbName, context, null);

--- a/src/main/java/org/mongeez/Mongeez.java
+++ b/src/main/java/org/mongeez/Mongeez.java
@@ -21,6 +21,7 @@ import org.mongeez.validation.ChangeSetsValidator;
 import org.mongeez.validation.DefaultChangeSetsValidator;
 
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ public class Mongeez {
     private final static Logger logger = LoggerFactory.getLogger(Mongeez.class);
 
     private Mongo mongo = null;
+    private MongoClient mongoClient = null;
     private String dbName;
     private MongoAuth auth = null;
     private ChangeSetFileProvider changeSetFileProvider = null;
@@ -42,7 +44,13 @@ public class Mongeez {
 
     public void process() {
         List<ChangeSet> changeSets = getChangeSets();
-        new ChangeSetExecutor(mongo, dbName, context, auth).execute(changeSets);
+        if (mongo != null) {
+            new ChangeSetExecutor(mongo, dbName, context, auth).execute(changeSets);
+        } else if (mongoClient != null) {
+            new ChangeSetExecutor(mongoClient, dbName, context).execute(changeSets);
+        } else {
+            throw new IllegalStateException("Neither mongo nor mongoClient has been configured!");
+        }
     }
 
     private List<ChangeSet> getChangeSets() {
@@ -73,6 +81,10 @@ public class Mongeez {
                 }
             }
         }
+    }
+
+    public void setMongoClient(MongoClient mongoClient) {
+        this.mongoClient = mongoClient;
     }
 
     public void setMongo(Mongo mongo) {

--- a/src/main/java/org/mongeez/dao/MongeezDao.java
+++ b/src/main/java/org/mongeez/dao/MongeezDao.java
@@ -34,6 +34,11 @@ public class MongeezDao {
     private DB db;
     private List<ChangeSetAttribute> changeSetAttributes;
 
+    public MongeezDao(MongoClient mongoClient, String databaseName) {
+        db = mongoClient.getDB(databaseName);
+        configure();
+    }
+
     public MongeezDao(Mongo mongo, String databaseName) {
         this(mongo, databaseName, null);
     }

--- a/src/test/java/org/mongeez/MongeezTest.java
+++ b/src/test/java/org/mongeez/MongeezTest.java
@@ -17,6 +17,7 @@ import static org.testng.Assert.assertEquals;
 import com.mongodb.DB;
 import com.mongodb.DBCursor;
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 
 import org.mongeez.validation.ValidationException;
 import org.springframework.core.io.ClassPathResource;
@@ -45,9 +46,33 @@ public class MongeezTest {
         return mongeez;
     }
 
+    private Mongeez createWithMongoClient(String path) {
+        MongoClient mongoClient = new MongoClient();
+        db = mongoClient.getDB(dbName);
+        db.dropDatabase();
+
+        Mongeez mongeez = new Mongeez();
+        mongeez.setFile(new ClassPathResource(path));
+        mongeez.setMongoClient(mongoClient);
+        mongeez.setDbName(dbName);
+        return mongeez;
+    }
+
     @Test(groups = "dao")
     public void testMongeez() throws Exception {
         Mongeez mongeez = create("mongeez.xml");
+
+        mongeez.process();
+
+        assertEquals(db.getCollection("mongeez").count(), 5);
+
+        assertEquals(db.getCollection("organization").count(), 2);
+        assertEquals(db.getCollection("user").count(), 2);
+    }
+
+    @Test(groups = "dao")
+    public void testMongeezWithMongoClient() throws Exception {
+        Mongeez mongeez = createWithMongoClient("mongeez.xml");
 
         mongeez.process();
 


### PR DESCRIPTION
instead of Mongo. A MongoClient has all the database authentication
already configured and can be used directly.