### PR TITLE
Update mongo java driver version to 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>3.0.1</version>
+            <version>3.4.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Latest MongoDB Atlas requires java driver version 3.4. Tests are passing at this version.