### PR TITLE
Add run as command attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>3.0.1</version>
+            <version>3.10.2</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/mongeez/ChangeSetExecutor.java
+++ b/src/main/java/org/mongeez/ChangeSetExecutor.java
@@ -12,11 +12,10 @@
 
 package org.mongeez;
 
+import com.mongodb.Mongo;
 import org.mongeez.commands.ChangeSet;
 import org.mongeez.commands.Script;
 import org.mongeez.dao.MongeezDao;
-
-import com.mongodb.Mongo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +56,11 @@ public class ChangeSetExecutor {
     private void execute(ChangeSet changeSet) {
         try {
             for (Script command : changeSet.getCommands()) {
-                command.run(dao);
+                if (changeSet.isRunAsCommand()) {
+                    command.runAsCommand(dao);
+                } else {
+                    command.run(dao);
+                }
             }
         } catch (RuntimeException e) {
             if (changeSet.isFailOnError()) {

--- a/src/main/java/org/mongeez/commands/ChangeSet.java
+++ b/src/main/java/org/mongeez/commands/ChangeSet.java
@@ -26,6 +26,16 @@ public class ChangeSet {
     private boolean failOnError = true;
     private boolean runAlways;
 
+    private boolean runAsCommand;
+
+    public boolean isRunAsCommand() {
+        return runAsCommand;
+    }
+
+    public void setRunAsCommand(boolean runAsCommand) {
+        this.runAsCommand = runAsCommand;
+    }
+
     private List<Script> commands = new ArrayList<Script>();
 
     public String getChangeId() {

--- a/src/main/java/org/mongeez/commands/Script.java
+++ b/src/main/java/org/mongeez/commands/Script.java
@@ -31,4 +31,8 @@ public class Script {
     public void run(MongeezDao dao) {
         dao.runScript(body);
     }
+
+    public void runAsCommand(MongeezDao dao) {
+        dao.runScriptAsCommand(body);
+    }
 }

--- a/src/main/java/org/mongeez/reader/FormattedJavascriptChangeSetReader.java
+++ b/src/main/java/org/mongeez/reader/FormattedJavascriptChangeSetReader.java
@@ -2,7 +2,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
@@ -36,6 +36,9 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
                     Pattern.CASE_INSENSITIVE);
     private static final Pattern ATTRIBUTE_RUN_ALWAYS_PATTERN =
             Pattern.compile(".*runAlways:(\\w+).*",
+                    Pattern.CASE_INSENSITIVE);
+    private static final Pattern ATTRIBUTE_RUN_AS_COMMAND_PATTERN =
+            Pattern.compile(".*runAsCommand:(\\w+).*",
                     Pattern.CASE_INSENSITIVE);
     private static final Pattern ATTRIBUTE_CONTEXTS_PATTERN =
             Pattern.compile(".*contexts:([\\w]+(?:, *[\\w]+)*).*",
@@ -140,6 +143,7 @@ public class FormattedJavascriptChangeSetReader implements ChangeSetReader {
             changeSet.setAuthor(changeSetMatcher.group(1));
             changeSet.setChangeId(changeSetMatcher.group(2));
             changeSet.setRunAlways(parseAttribute(ATTRIBUTE_RUN_ALWAYS_PATTERN.matcher(line), false));
+            changeSet.setRunAsCommand(parseAttribute(ATTRIBUTE_RUN_AS_COMMAND_PATTERN.matcher(line), false));
             changeSet.setContexts(parseAttributeString(ATTRIBUTE_CONTEXTS_PATTERN.matcher(line)));
         }
         return changeSet;

--- a/src/test/java/org/mongeez/MongeezTest.java
+++ b/src/test/java/org/mongeez/MongeezTest.java
@@ -12,16 +12,16 @@
 
 package org.mongeez;
 
-import static org.testng.Assert.assertEquals;
-
 import com.mongodb.DB;
-import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
 import com.mongodb.Mongo;
-
+import com.mongodb.QueryBuilder;
 import org.mongeez.validation.ValidationException;
 import org.springframework.core.io.ClassPathResource;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 @Test
 public class MongeezTest {
@@ -150,5 +150,30 @@ public class MongeezTest {
     public void testFailDuplicateIds() throws Exception {
         Mongeez mongeez = create("mongeez_fail_on_duplicate_changeset_ids.xml");
         mongeez.process();
+    }
+
+    @Test(groups = "commands")
+    public void testScriptWithCommand(){
+        Mongeez mongeez = create("mongeez_with_command_insert.xml");
+        mongeez.process();
+        assertEquals(db.getCollection("commands").count(), 1);
+
+        DBObject q = new QueryBuilder().put("code").is("CODE1").get();
+        DBObject result = db.getCollection("commands").findOne(q);
+        assertEquals(((String) result.get("description")), "example of organization1");
+    }
+
+    @Test(groups = "commands")
+    public void testScriptWithCommandUpdate(){
+        Mongeez mongeez = create("mongeez_with_command_insert.xml");
+        mongeez.process();
+
+        mongeez = create("mongeez_with_command_update.xml");
+        mongeez.process();
+        assertEquals(db.getCollection("commands").count(), 1);
+
+        DBObject q = new QueryBuilder().put("code").is("CODE1").get();
+        DBObject result = db.getCollection("commands").findOne(q);
+        assertEquals(((String) result.get("description")), "updated description of organization1");
     }
 }

--- a/src/test/resources/changeset_with_command_insert.xml
+++ b/src/test/resources/changeset_with_command_insert.xml
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2011 SecondMarket Labs, LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and limitations under the License.
+  -->
+
+<mongoChangeLog>
+    <changeSet changeId="ChangeSet-with-command-insert" author="dlozovoy" runAsCommand="true">
+        <script>
+            {insert: "commands",  documents: [ {"code" : "CODE1", "description": "example of organization1", "version" : 0}]}
+        </script>
+    </changeSet>
+</mongoChangeLog>

--- a/src/test/resources/changeset_with_command_update.xml
+++ b/src/test/resources/changeset_with_command_update.xml
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2011 SecondMarket Labs, LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and limitations under the License.
+  -->
+
+<mongoChangeLog>
+    <changeSet changeId="ChangeSet-with-command-update" author="dlozovoy" runAsCommand="true">
+        <script>
+            {update: "commands", updates:[ {q:{"code" : "CODE1"},u:{$set:{"description": "updated description of organization1"}}}] }
+        </script>
+    </changeSet>
+</mongoChangeLog>

--- a/src/test/resources/mongeez_with_command_insert.xml
+++ b/src/test/resources/mongeez_with_command_insert.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Copyright 2011 SecondMarket Labs, LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and limitations under the License.
+  -->
+
+<changeFiles>
+    <file path="changeset_with_command_insert.xml"/>
+</changeFiles>

--- a/src/test/resources/mongeez_with_command_update.xml
+++ b/src/test/resources/mongeez_with_command_update.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Copyright 2011 SecondMarket Labs, LLC.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and limitations under the License.
+  -->
+
+<changeFiles>
+    <file path="changeset_with_command_update.xml"/>
+</changeFiles>


### PR DESCRIPTION
###  Added new `runAsCommand` attribute to run scripts using the `db.runCommand()` method.

- It allows running scripts on MongoDB versions higher than 4.2.
- If the `runAsCommand` attribute set to `true`, script will be executed by the command `db.runCommand()` and can run on MongoDB versions above 4.2

By default (and for backward compatibility), the `runAsCommand`attribute set to `false`, and the `db.eval()` command used to execute the script (deprecated since MongoDB version 3.0)<br>
##### Examples of scripts with the `runAsCommand` attribute
```xml
<mongoChangeLog>
    <changeSet changeId="ChangeSet-with-command-insert" author="dlozovoy" runAsCommand="true">
        <script>
            {insert: "commands",  documents: [ {"code" : "CODE1", "description": "example of organization1", "version" : 0}]}
        </script>
    </changeSet>
</mongoChangeLog>
```
```xml
<mongoChangeLog>
    <changeSet changeId="ChangeSet-with-command-update" author="dlozovoy" runAsCommand="true">
        <script>
            {update: "commands", updates:[ {q:{"code" : "CODE1"},u:{$set:{"description": "updated description of organization1"}}}] }
        </script>
    </changeSet>
</mongoChangeLog>
```